### PR TITLE
Channel order fix

### DIFF
--- a/tvheadend-ios-lib/TVHChannel.m
+++ b/tvheadend-ios-lib/TVHChannel.m
@@ -289,12 +289,17 @@
 }
 
 - (NSComparisonResult)compareByNumber:(TVHChannel *)otherObject {
-    if ( self.number < otherObject.number ) {
-        return NSOrderedAscending;
-    } else if ( self.number > otherObject.number ) {
+    
+    if(self.number == otherObject.number) {
+        return NSOrderedSame;
+    } else if(self.number == 0)  //Channels without number should be placed last - treat number 0 as infinity
+    {
         return NSOrderedDescending;
+    } else if(otherObject.number == 0) {
+        return NSOrderedAscending;
     }
-    return NSOrderedSame;
+    
+    return self.number < otherObject.number ? NSOrderedAscending : NSOrderedDescending;
 }
 
 - (void)resetChannelEpgStore {

--- a/tvheadend-ios-libTests/TVHChannelTests.m
+++ b/tvheadend-ios-libTests/TVHChannelTests.m
@@ -109,4 +109,22 @@
     XCTAssertTrue( ([chepg.programs count] == 0), @"epg day was not removed when last epg got removed");
 }
 
+
+- (void)testSortByNumber {
+    TVHChannel *channel1 = [self channel];
+    TVHChannel *channel2 = [self channel];
+    TVHChannel *channelNoNumber = [self channel];
+    
+    channel1.number = 1;
+    channel2.number = 2;
+    
+    XCTAssertEqual(NSOrderedAscending, [channel1 compareByNumber:channel2]);
+    XCTAssertEqual(NSOrderedAscending, [channel2 compareByNumber:channelNoNumber]);
+    XCTAssertEqual(NSOrderedDescending, [channelNoNumber compareByNumber:channel2]);
+    XCTAssertEqual(NSOrderedSame, [channel1 compareByNumber:channel1]);
+    XCTAssertEqual(NSOrderedSame, [channelNoNumber compareByNumber:channelNoNumber]);
+
+}
+
+
 @end


### PR DESCRIPTION
Changes how channels without a number are handled when sorting.
Channels without a number are placed last.