### PR TITLE
Update TVHServerSettings.m

### DIFF
--- a/tvheadend-ios-lib/TVHServerSettings.m
+++ b/tvheadend-ios-lib/TVHServerSettings.m
@@ -177,8 +177,8 @@
         return [NSString stringWithFormat:@"http%@://%@:%@%@", self.useHTTPS, self.ip, self.port, self.normalisedWebroot];
     } else {
         return [NSString stringWithFormat:@"http%@://%@:%@@%@:%@%@", self.useHTTPS,
-                [self.username stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]],
-                [self.password stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]],
+                [self.username stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLUserAllowedCharacterSet]],
+                [self.password stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPasswordAllowedCharacterSet]],
                 self.ip, self.port, self.normalisedWebroot];
     }
 }


### PR DESCRIPTION
Encode username and password in the suggested way using the pre-defined character sets. URLHostAllowedCharacterSet is _definitely_ the wrong character set!

It allows only numbers and characters and not even _underlines_ or any special characters! ;-)